### PR TITLE
Expand roles/personas and add handoff checklist (addresses issue #4)

### DIFF
--- a/docs/cross-role-handoff-checklist.md
+++ b/docs/cross-role-handoff-checklist.md
@@ -1,0 +1,8 @@
+# Cross-Role Handoff Checklist
+
+- [ ] Requirements reviewed by Product Manager & Business Analyst
+- [ ] User stories/designs validated by UX/UI Designer
+- [ ] QA test plan reviewed by QA Engineer
+- [ ] Security review booked with Security Lead
+- [ ] DevOps confirmed deployment readiness
+- [ ] Sponsor approval for key milestone(s)

--- a/docs/octoacme-roles-and-personas.md
+++ b/docs/octoacme-roles-and-personas.md
@@ -75,7 +75,119 @@ Project Managers coordinate delivery activities, manage schedules, risks, and co
 
 ---
 
+## QA Engineer
+
+### Role Summary
+Plans and executes test strategies, triages bugs, and signs off releases for software quality.
+
+### Responsibilities
+- Design and execute manual/automated tests
+- Collaborate on acceptance criteria
+- Run regression/release tests
+- Triage bugs and perform release validation
+
+### Interactions
+- Works with Developers to resolve defects
+- Coordinates with PM on test planning and release scope
+
+---
+
+## UX/UI Designer
+
+### Role Summary
+Designs user interfaces, prototypes, and tests usability and accessibility.
+
+### Responsibilities
+- Create wireframes, visual designs, and prototypes
+- Perform usability and accessibility testing
+- Collaborate on requirements and feature specs
+
+### Interactions
+- Works with Product Manager for requirements/goals
+- Collaborates directly with Developers for implementation
+- Engages Stakeholders for design feedback
+
+---
+
+## Security Lead
+
+### Role Summary
+Ensures application and infrastructure security throughout the project lifecycle.
+
+### Responsibilities
+- Conduct risk/threat assessments
+- Review code and dependencies for vulnerabilities
+- Lead incident response
+- Advise teams on secure patterns and compliance
+
+### Interactions
+- Supports Developers for security implementation
+- Collaborates with PM on risk mitigation tracking
+
+---
+
+## Business Analyst
+
+### Role Summary
+Translates business needs into technical requirements and analyzes data for improvement.
+
+### Responsibilities
+- Gather requirements and map processes
+- Recommend improvements and document changes
+- Track metrics to drive better delivery
+
+### Interactions
+- Works closely with Product Managers on needs and data
+- Supports Developers for solution feasibility
+- Engages Stakeholders for input and approval
+
+---
+
+## Stakeholder/Sponsor
+
+### Role Summary
+Provides strategic input, allocates resources, and removes blockers.
+
+### Responsibilities
+- Approve milestones and project direction
+- Allocate resources and drive decisions
+- Remove organizational barriers
+
+### Interactions
+- Receives updates from PM and Product Manager
+- Engages teams during decision gates and escalations
+
+---
+
+## DevOps Engineer
+
+### Role Summary
+Manages CI/CD pipelines, infrastructure, deployment, and reliability.
+
+### Responsibilities
+- Set up, monitor, and maintain CI/CD systems
+- Automate deployments and monitoring
+- Respond to outages and production issues
+
+### Interactions
+- Collaborates with Developers and QA on release cycles
+- Coordinates with PM for deployment planning
+
+---
+
+## Cross-Persona Interactions
+
+| Persona           | Collaborates With                    | Main Touchpoints                  |
+|-------------------|-------------------------------------|-----------------------------------|
+| QA Engineer       | Dev, PM, PdM                        | UAT, release testing              |
+| UX Designer       | PdM, Dev, Stakeholder               | Design reviews, specs, prototypes |
+| Security Lead     | Dev, PM, Stakeholder                | Risk register, incident response  |
+| Business Analyst  | PdM, Dev, Stakeholder               | Requirements, process docs        |
+| Sponsor           | PM, PdM, Stakeholder                | Decision gates, escalations       |
+| DevOps Engineer   | Dev, QA, PM                         | Deployments, CI/CD, post-release  |
+
+---
+
 ## How these personas are used in the exercise
 - Use these persona definitions to frame scenarios and sample interactions in the Skills Exercise.
 - Each persona can be used as a persona prompt for Copilot Spaces to shape role-specific guidance.
-


### PR DESCRIPTION
Addresses gaps in role clarity and cross-functional handoffs based on analysis in issue #4. Updates docs/octoacme-roles-and-personas.md and adds a cross-role handoff checklist for process improvement.\n\nRelates to #4.